### PR TITLE
Add utility-pole tool plan and Phase 0 test wrapper

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,238 @@
+# Utility Pole Measurement & Classification — Plan
+
+A vision-first tool for measuring and classifying utility poles from phone
+video or photo bursts, built on top of the `lingbot-map` streaming 3D
+reconstruction model. No LiDAR, no RTK GNSS, no measuring stick — the
+Tesla-style approach: cameras only, resolve the rest in software.
+
+---
+
+## 1. What `lingbot-map` provides (the base)
+
+`lingbot-map` is a feed-forward 3D reconstruction foundation model (a
+successor to VGGT, DINOv2 backbone + geometric-context transformer). From a
+folder of images or a video, a single forward pass produces, per frame:
+
+- `extrinsic` — camera pose (c2w) in a common world frame
+- `intrinsic` — focal / principal point
+- `depth` + `depth_conf` — dense per-pixel depth
+- `world_points` + `world_points_conf` — dense per-pixel 3D points in the
+  shared world frame
+- ~20 FPS streaming at 518×378; windowed mode for long sequences
+
+This is exactly the primitive needed for vision-first pole measurement:
+**camera poses + dense world-frame point cloud from images alone**.
+`demo.py` already handles video → frames → point cloud → viser viewer
+(`demo.py:45-100`, `demo.py:370-426`). The gaps for a pole-measurement tool
+are metric-scale resolution, segmentation/classification, measurement UI,
+and georeferencing.
+
+## 2. Why vision-first ("Tesla approach") fits
+
+Existing utility-pole tools (Katapult Pro, IKE GeoSpatial, SPIDA, Pointivo,
+Osmose, Alden One) rely on one of:
+
+- **LiDAR + GNSS** (Katapult "stick", IKE): accurate, expensive, requires
+  field crews/trucks.
+- **Measuring stick + manual photo annotation** (Katapult, SPIDA field):
+  cheap but slow and error-prone.
+- **RTK GNSS + photogrammetry** (Pointivo): semi-automated, still needs
+  survey-grade hardware.
+
+A vision-first pipeline replaces all of those with *"walk around the pole
+with a phone, upload, get measurements."* The tradeoff is monocular metric
+scale, which is solvable with cheap cues (see §4).
+
+## 3. End-to-end pipeline
+
+```
+User capture (phone video / photo burst)
+        │
+        ▼
+[1] Frame extraction + pose estimation (lingbot-map)   ← exists
+        │   per-frame extrinsics, intrinsics, depth, world_points
+        ▼
+[2] Metric scale resolution                            ← NEW
+        │   uplift reconstruction to real-world meters
+        ▼
+[3] Pole detection & segmentation (SAM 2 + DINOv2)     ← NEW
+        │   2D masks per frame: pole body, crossarm, attachments
+        ▼
+[4] Mask → 3D fusion                                   ← NEW
+        │   3D point-cloud subsets per object class
+        ▼
+[5] Pole-axis fit + ground-plane fit (RANSAC)          ← NEW
+        │   vertical pole line in world frame
+        ▼
+[6] Measurements                                        ← NEW
+        │   pole height, attachment heights, lean, diameter
+        ▼
+[7] Classification                                      ← NEW
+        │   pole material/class, attachment types
+        ▼
+[8] Export                                              ← NEW
+        │   GeoJSON / KML / Katapult-compatible JSON, PDF report
+        ▼
+[9] Browser app (extend viser viewer into a measurement UI)
+```
+
+## 4. Solving metric scale (the critical unlock)
+
+Monocular feed-forward reconstruction is **scale-ambiguous** by default.
+Four viable cues, in order of preference — support all, fall back
+gracefully:
+
+1. **Phone AR session data (ARKit / ARCore)** — if users capture via a
+   companion mobile app, visual-inertial odometry gives metric translations.
+   Best UX.
+2. **EXIF GNSS baseline** — modern phones embed per-photo lat/lon/alt. Fit
+   Sim(3) between `lingbot-map` camera translations and EXIF positions;
+   recovers scale when the user walks ≥1–2 m around the pole. Zero extra
+   effort for users.
+3. **Known reference in scene** — user taps two points on a standard
+   reference (meter stick, printed AprilTag, known crossarm length). Manual
+   one-time calibration per capture.
+4. **Learned pole-diameter prior** — mean class diameter (e.g., Class-4 40′
+   wood ≈ 9.5″ at 6′ above grade) as a weak prior when nothing else
+   exists; flagged as "estimated" in the report.
+
+**Recommendation:** ship #2 as default + #3 as a tap-to-calibrate override.
+
+## 5. Where Meta models fit
+
+Beyond the DINOv2 trunk already inside `lingbot-map`, three Meta models
+slot in cleanly:
+
+- **SAM 2** — video-native segmentation. User clicks the pole once in one
+  frame; SAM 2 propagates the mask across the whole video. Same for each
+  attachment. This is the unlock for labor-free 2D → 3D object isolation.
+- **DINOv2 features (reused from the aggregator)** — attach a small
+  linear/MLP head for pole classification (wood/steel/concrete/composite,
+  class 1–6) and attachment-type classification. No new backbone needed;
+  we tap into features already computed during reconstruction. Significant
+  compute win.
+- **CoTracker3** (optional) — dense point tracking for cross-frame mask
+  consistency and pole-lean / pole-sway detection between frames.
+
+Non-Meta but complementary: **Depth Anything v2** as a fallback for
+single-still uploads (`lingbot-map` needs ≥2 views).
+
+## 6. Measurement primitives
+
+Once we have a scaled point cloud + per-class masks:
+
+- **Ground plane** — RANSAC plane fit restricted to points within R meters
+  of the pole base, normal near +Z.
+- **Pole axis** — RANSAC 3D line through pole-masked points with
+  near-vertical prior.
+- **Pole height** — distance along axis from ground-plane intersection to
+  top-of-pole cluster.
+- **Attachment height** — for each attachment segment, project centroid (or
+  lowest point for clearance) onto axis, report distance from ground.
+- **Pole lean** — angle between pole axis and gravity (phone IMU if
+  available, else ground-plane normal).
+- **Diameter at breast height** — cylinder fit on pole points in the 4.5′
+  band.
+- **Uncertainty** — propagate `depth_conf` / `world_points_conf` through
+  every measurement; report ±σ.
+
+## 7. Georeferencing & export
+
+- Anchor the world frame to WGS84 via the Sim(3) solved in §4 step 2
+  (EXIF GNSS). Every measured 3D point gets lat/lon/alt.
+- Export targets:
+  - **GeoJSON / KML** — QGIS, Google Earth, ArcGIS.
+  - **Katapult Pro-compatible JSON** — reverse-engineer from a sample
+    export; this is the integration that matters for utilities already on
+    Katapult.
+  - **SPIDAcalc XML** — for structural-loading handoff.
+  - **PDF inspection report** — annotated photos + measurement table,
+    signable.
+
+## 8. Competitive positioning
+
+| Tool            | Input                  | Scale source         | Automation | Cost                 |
+|-----------------|------------------------|----------------------|------------|----------------------|
+| Katapult Pro    | Photos + measuring stick | Manual stick        | Low        | Seat + field labor   |
+| IKE GeoSpatial  | LiDAR + RTK GNSS       | RTK GNSS             | Medium     | Hardware + service   |
+| Pointivo        | Multi-image + RTK      | RTK GNSS             | Medium     | Hardware + service   |
+| SPIDA field     | Photo + stick          | Manual               | Low        | Labor                |
+| **This tool**   | **Phone video**        | **EXIF / AR / tag**  | **High**   | **App only**         |
+
+Pitch: **"90% of Katapult's measurement output from a 30-second phone
+walk-around, no stick, no RTK"** — with graceful accuracy degradation
+rather than a hard hardware gate.
+
+## 9. Phased build
+
+### Phase 0 — Verify the base (1–2 days)
+- Run `demo.py` (and `scripts/test_pole.py`) on a real utility-pole video.
+- Confirm dense point-cloud quality, pose stability, and whether the pole
+  reconstructs as a clean vertical structure.
+- **This is the first gate.** Thin vertical structures are a known hard
+  case for feed-forward MVS. If the pole is disintegrating, evaluate:
+  stage-1 VGGT checkpoint, keyframe density, windowed mode, or pairing
+  with a monocular depth prior.
+
+### Phase 1 — Measurement MVP (2–3 weeks)
+- EXIF GNSS Sim(3) scale solver.
+- SAM 2 single-click pole segmentation (video-propagated).
+- Ground-plane + pole-axis fit, height measurement, single attachment
+  height.
+- Extend the viser viewer with a "measure" panel: click-to-measure on the
+  3D point cloud, ruler overlay.
+
+### Phase 2 — Classification & bulk attachments (3–4 weeks)
+- DINOv2-head classifier for pole material + class and attachment types.
+  Start zero-shot via CLIP for the long tail, fine-tune on a small labeled
+  set as data accrues.
+- Multi-attachment segmentation (SAM 2 + detector bootstrapped from
+  CLIP/Grounding-DINO prompts like "transformer", "insulator",
+  "streetlight").
+- Confidence/uncertainty reporting.
+
+### Phase 3 — Georeferencing & export (2 weeks)
+- WGS84 anchoring, GeoJSON/KML export, PDF report, Katapult JSON.
+
+### Phase 4 — Capture app + cloud (ongoing)
+- Thin iOS/Android capture app recording video + ARKit/ARCore pose + GNSS,
+  uploads to a cloud worker running the pipeline; web app shows
+  interactive 3D + measurements.
+
+## 10. Risks to validate early
+
+- **Thin vertical structures in feed-forward MVS.** Biggest unknown.
+  Validate in Phase 0 before committing to the architecture.
+- **Metric scale drift on short baselines.** Users standing still won't
+  give a GNSS baseline. Detect and prompt the user to walk around the pole.
+- **Occluded bases.** Grass, fences, parked cars. Ground-plane fit needs
+  robust handling; may require a user-assisted "tap the ground" step.
+- **Daylight / backlighting.** Poles against bright sky. Sky masking
+  exists (`demo.py:286`); extend to general over-exposure handling.
+- **Accuracy claims.** Utilities often need survey-grade (±0.1 ft) for
+  make-ready engineering. Be explicit about precision tier — position the
+  tool as *pre-survey triage + inventory* initially, not as a replacement
+  for RTK-grade engineering input.
+
+---
+
+## Phase 0 runbook (local)
+
+```bash
+# Env
+conda create -n lingbot-map python=3.10 -y
+conda activate lingbot-map
+pip install torch==2.9.1 torchvision==0.24.1 --index-url https://download.pytorch.org/whl/cu128
+pip install -e ".[vis]"
+
+# Checkpoint (one-time, several GB)
+huggingface-cli download robbyant/lingbot-map --local-dir ./checkpoints
+
+# Test wrapper: dumps a .ply and prints sanity-check stats
+python scripts/test_pole.py \
+    --model_path ./checkpoints/lingbot-map.pt \
+    --video_path /path/to/pole.MOV \
+    --output pole_cloud.ply
+
+# Open pole_cloud.ply in CloudCompare or MeshLab to inspect.
+```

--- a/scripts/test_pole.py
+++ b/scripts/test_pole.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Pole-capture test wrapper for lingbot-map.
+
+Opinionated defaults for short phone video walk-arounds of utility poles:
+  - fps=8 (a slow walk, a few frames per second is enough)
+  - sky masking on by default
+  - confidence filter at the 50th percentile
+  - dumps a binary .ply you can open in CloudCompare / MeshLab
+  - prints scene extent, frame count, and (if present) EXIF GNSS stats as
+    a first sanity check before investing in the full pipeline.
+
+Usage:
+    python scripts/test_pole.py \\
+        --model_path /path/to/lingbot-map.pt \\
+        --video_path /path/to/pole.MOV \\
+        --output pole_cloud.ply
+
+This is a Phase 0 smoke test. If the pole reconstructs as a clean vertical
+structure here, we have a viable base for the full measurement pipeline
+(see PLAN.md).
+"""
+import argparse
+import os
+import sys
+import time
+from argparse import Namespace
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import torch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from demo import load_images, load_model, postprocess
+
+
+def _build_model_args(model_path, image_size=518):
+    return Namespace(
+        model_path=model_path,
+        image_size=image_size,
+        patch_size=14,
+        mode="streaming",
+        enable_3d_rope=True,
+        max_frame_num=1024,
+        num_scale_frames=8,
+        kv_cache_sliding_window=64,
+        camera_num_iterations=4,
+        use_sdpa=False,
+    )
+
+
+def _write_ply_binary(path, xyz, rgb):
+    """Minimal binary PLY writer — no trimesh dependency."""
+    assert xyz.shape[0] == rgb.shape[0]
+    n = xyz.shape[0]
+    header = (
+        "ply\nformat binary_little_endian 1.0\n"
+        f"element vertex {n}\n"
+        "property float x\nproperty float y\nproperty float z\n"
+        "property uchar red\nproperty uchar green\nproperty uchar blue\n"
+        "end_header\n"
+    ).encode("ascii")
+    verts = np.empty(
+        n,
+        dtype=[
+            ("x", "f4"), ("y", "f4"), ("z", "f4"),
+            ("r", "u1"), ("g", "u1"), ("b", "u1"),
+        ],
+    )
+    verts["x"], verts["y"], verts["z"] = xyz[:, 0], xyz[:, 1], xyz[:, 2]
+    verts["r"], verts["g"], verts["b"] = rgb[:, 0], rgb[:, 1], rgb[:, 2]
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(verts.tobytes())
+
+
+def _probe_exif_gnss(image_folder):
+    """Report whether source frames carry GPS EXIF — required for Sim(3) scale recovery later."""
+    try:
+        from PIL import Image, ExifTags
+    except ImportError:
+        return None
+    if not image_folder or not os.path.isdir(image_folder):
+        return None
+    sample = None
+    for name in sorted(os.listdir(image_folder)):
+        if name.lower().endswith((".jpg", ".jpeg", ".png")):
+            sample = os.path.join(image_folder, name)
+            break
+    if sample is None:
+        return None
+    try:
+        img = Image.open(sample)
+        exif = img._getexif() or {}
+        tag_map = {ExifTags.TAGS.get(k, k): v for k, v in exif.items()}
+        return tag_map.get("GPSInfo")
+    except Exception:
+        return None
+
+
+def main():
+    p = argparse.ArgumentParser(description="Phase 0 pole-capture test for lingbot-map.")
+    p.add_argument("--model_path", required=True)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--video_path")
+    src.add_argument("--image_folder")
+    p.add_argument("--output", default="pole_cloud.ply")
+    p.add_argument("--fps", type=int, default=8, help="Frame sample rate when reading video.")
+    p.add_argument("--first_k", type=int, default=None, help="Use only the first K frames.")
+    p.add_argument("--conf_percentile", type=float, default=50.0,
+                   help="Drop points below this world_points_conf percentile.")
+    p.add_argument("--mask_sky", action=argparse.BooleanOptionalAction, default=True,
+                   help="Apply sky segmentation (recommended for outdoor pole shots).")
+    p.add_argument("--image_size", type=int, default=518)
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+    if device.type != "cuda":
+        print("Warning: CUDA unavailable. Inference will be slow and may OOM.")
+
+    # 1) Frames
+    t0 = time.time()
+    images, paths, resolved_folder = load_images(
+        image_folder=args.image_folder,
+        video_path=args.video_path,
+        fps=args.fps,
+        first_k=args.first_k,
+        image_size=args.image_size,
+        patch_size=14,
+    )
+    print(f"Loaded {images.shape[0]} frames in {time.time() - t0:.1f}s (source: {resolved_folder})")
+
+    # 2) GNSS sanity check (future scale solver input)
+    gps = _probe_exif_gnss(resolved_folder)
+    if gps:
+        print("[scale] EXIF GPSInfo present — Sim(3) scale recovery will be feasible in Phase 1.")
+    else:
+        print("[scale] No EXIF GPSInfo on source frames. Reconstruction will be scale-ambiguous "
+              "until a known reference or AR pose stream is supplied.")
+
+    # 3) Model
+    model = load_model(_build_model_args(args.model_path, args.image_size), device)
+
+    if torch.cuda.is_available():
+        dtype = torch.bfloat16 if torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+        if getattr(model, "aggregator", None) is not None:
+            model.aggregator = model.aggregator.to(dtype=dtype)
+    else:
+        dtype = torch.float32
+
+    images = images.to(device)
+    n_frames = images.shape[0]
+    keyframe_interval = 1 if n_frames <= 320 else (n_frames + 319) // 320
+
+    # 4) Inference
+    print(f"Running streaming inference: {n_frames} frames, "
+          f"keyframe_interval={keyframe_interval}, dtype={dtype}")
+    t0 = time.time()
+    with torch.no_grad(), torch.amp.autocast("cuda", dtype=dtype):
+        predictions = model.inference_streaming(
+            images,
+            num_scale_frames=8,
+            keyframe_interval=keyframe_interval,
+            output_device=torch.device("cpu"),
+        )
+    print(f"Inference finished in {time.time() - t0:.1f}s")
+    if torch.cuda.is_available():
+        print(f"GPU peak: {torch.cuda.max_memory_allocated() / 1e9:.2f} GB")
+
+    # 5) Post-process (moves tensors to CPU; pops predictions['images'])
+    images_for_post = predictions.get("images", images)
+    predictions, images_cpu = postprocess(predictions, images_for_post)
+
+    # 6) Point cloud
+    pts = predictions["world_points"].numpy()          # (S, H, W, 3)
+    conf = predictions["world_points_conf"].numpy()    # (S, H, W)
+    imgs_np = images_cpu.numpy() if hasattr(images_cpu, "numpy") else np.asarray(images_cpu)
+    # images_cpu is (S, 3, H, W) in [0, 1]
+    rgb_full = np.transpose(imgs_np, (0, 2, 3, 1))
+
+    xyz = pts.reshape(-1, 3)
+    col = (rgb_full.reshape(-1, 3) * 255.0).clip(0, 255).astype(np.uint8)
+    c = conf.reshape(-1)
+
+    thr = np.percentile(c, args.conf_percentile) if args.conf_percentile > 0 else 0.0
+    keep = (c >= thr) & (c > 1e-5)
+    xyz, col = xyz[keep], col[keep]
+    print(f"Kept {keep.sum():,} / {keep.size:,} points "
+          f"(>= p{args.conf_percentile:.0f} confidence).")
+
+    if xyz.size == 0:
+        print("No points survived filtering. Lower --conf_percentile or check input quality.")
+        return
+
+    # 7) Scene extent (sanity check — is anything reconstructed?)
+    lo = np.percentile(xyz, 5, axis=0)
+    hi = np.percentile(xyz, 95, axis=0)
+    extent = hi - lo
+    print(f"Scene 5–95% extent (model units): "
+          f"x={extent[0]:.2f}  y={extent[1]:.2f}  z={extent[2]:.2f}")
+    print("  (Units are scale-ambiguous until resolved from EXIF / AR / reference.)")
+
+    # 8) Save
+    _write_ply_binary(args.output, xyz.astype(np.float32), col)
+    print(f"Wrote {args.output}  ({xyz.shape[0]:,} points)")
+    print("Next: open in CloudCompare or MeshLab and verify the pole appears as a clean "
+          "vertical structure. That's the Phase 0 gate.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
PLAN.md captures the vision-first approach (no LiDAR/RTK), the pipeline, metric-scale options (EXIF GNSS / AR / tag / prior), Meta-model fit (SAM 2, DINOv2, CoTracker), and a phased build.

scripts/test_pole.py is the Phase 0 smoke test: runs lingbot-map with pole-capture defaults against a video or image folder, filters by confidence, and writes a binary PLY plus scene-extent and GNSS sanity output. No trimesh/viser dependency so it runs headless.

https://claude.ai/code/session_01Eupq9oYLKTrEwmjeuHwbEd