### PR TITLE
Add Apple Silicon (MPS) support with bf16 autocast

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -219,7 +219,7 @@ def _warm_streaming(model, images, scale_frames, warm_stream_n, dtype,
     for _ in range(passes):
         model.clean_kv_cache()
         torch.compiler.cudagraph_mark_step_begin()
-        with torch.no_grad(), torch.amp.autocast("cuda", dtype=dtype):
+        with torch.no_grad(), torch.amp.autocast(images.device.type, dtype=dtype, enabled=dtype != torch.float32):
             model.forward(
                 warm_scale,
                 num_frame_for_scale=scale_frames,
@@ -231,7 +231,7 @@ def _warm_streaming(model, images, scale_frames, warm_stream_n, dtype,
             if not is_keyframe:
                 model._set_skip_append(True)
             torch.compiler.cudagraph_mark_step_begin()
-            with torch.no_grad(), torch.amp.autocast("cuda", dtype=dtype):
+            with torch.no_grad(), torch.amp.autocast(images.device.type, dtype=dtype, enabled=dtype != torch.float32):
                 model.forward(
                     warm_stream[:, i:i + 1],
                     num_frame_for_scale=scale_frames,
@@ -418,7 +418,12 @@ def main():
     assert args.image_folder or args.video_path, \
         "Provide --image_folder or --video_path"
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
     # ── Load images & model ──────────────────────────────────────────────────
     t0 = time.time()
@@ -447,6 +452,8 @@ def main():
     # Pick inference dtype; autocast still runs for the ops that need fp32 (e.g. LayerNorm).
     if torch.cuda.is_available():
         dtype = torch.bfloat16 if torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+    elif device.type == "mps":
+        dtype = torch.bfloat16
     else:
         dtype = torch.float32
 
@@ -542,7 +549,8 @@ def main():
 
     output_device = torch.device("cpu") if args.offload_to_cpu else None
 
-    with torch.no_grad(), torch.amp.autocast("cuda", dtype=dtype):
+    autocast_ctx = torch.amp.autocast(device.type, dtype=dtype, enabled=dtype != torch.float32)
+    with torch.no_grad(), autocast_ctx:
         if args.mode == "streaming":
             predictions = model.inference_streaming(
                 images,

--- a/lingbot_map/layers/rope.py
+++ b/lingbot_map/layers/rope.py
@@ -362,6 +362,10 @@ class WanRotaryPosEmbed(nn.Module):
         """
 
         # 步骤1：将预计算的频率移到目标设备，并分割成三个维度
+        # MPS has no float64/complex128 — downcast the precomputed freqs to
+        # complex64 before moving them (precompute itself stays fp64 on CPU).
+        if torch.device(device).type == "mps" and self.freqs.dtype == torch.complex128:
+            self.freqs = self.freqs.to(torch.complex64)
         self.freqs = self.freqs.to(device)
         # 获取实际的维度分配
         if hasattr(self, 'fhw_dim') and self.fhw_dim is not None:

--- a/lingbot_map/models/gct_base.py
+++ b/lingbot_map/models/gct_base.py
@@ -166,7 +166,7 @@ class GCTBase(nn.Module, PyTorchModelHubMixin, ABC):
 
         camera_sliding_window = sliding_window_size if self.enable_camera_sliding_window else -1
 
-        with torch.amp.autocast('cuda', enabled=False):
+        with torch.amp.autocast(aggregated_tokens_list_fp32[0].device.type, enabled=False):
             pose_enc_list = self.camera_head(
                 aggregated_tokens_list_fp32,
                 mask=mask,
@@ -194,7 +194,7 @@ class GCTBase(nn.Module, PyTorchModelHubMixin, ABC):
         aggregated_tokens_list_fp32 = [t.float() for t in aggregated_tokens_list]
         images_fp32 = images.float()
 
-        with torch.amp.autocast('cuda', enabled=False):
+        with torch.amp.autocast(aggregated_tokens_list_fp32[0].device.type, enabled=False):
             depth, depth_conf = self.depth_head(
                 aggregated_tokens_list_fp32,
                 images=images_fp32,
@@ -216,7 +216,7 @@ class GCTBase(nn.Module, PyTorchModelHubMixin, ABC):
         aggregated_tokens_list_fp32 = [t.float() for t in aggregated_tokens_list]
         images_fp32 = images.float()
 
-        with torch.amp.autocast('cuda', enabled=False):
+        with torch.amp.autocast(aggregated_tokens_list_fp32[0].device.type, enabled=False):
             pts3d, pts3d_conf = self.point_head(
                 aggregated_tokens_list_fp32,
                 images=images_fp32,
@@ -238,7 +238,7 @@ class GCTBase(nn.Module, PyTorchModelHubMixin, ABC):
         aggregated_tokens_list_fp32 = [t.float() for t in aggregated_tokens_list]
         images_fp32 = images.float()
 
-        with torch.amp.autocast('cuda', enabled=False):
+        with torch.amp.autocast(aggregated_tokens_list_fp32[0].device.type, enabled=False):
             pts3d, pts3d_conf = self.local_point_head(
                 aggregated_tokens_list_fp32,
                 images=images_fp32,

--- a/lingbot_map/vis/point_cloud_viewer.py
+++ b/lingbot_map/vis/point_cloud_viewer.py
@@ -22,6 +22,7 @@ from typing import List, Optional, Dict, Any, Tuple
 import numpy as np
 import torch
 import cv2
+import matplotlib
 import matplotlib.cm as cm
 from tqdm.auto import tqdm
 
@@ -1045,7 +1046,7 @@ class PointCloudViewer:
             normalized_indices = np.array(list(range(num_cameras))) / (num_cameras - 1)
         else:
             normalized_indices = np.array([0.0])
-        cmap = cm.get_cmap('viridis')
+        cmap = matplotlib.colormaps.get_cmap('viridis')
         self.camera_colors = cmap(normalized_indices)
         return pcs, step_list
 

--- a/lingbot_map/vis/utils.py
+++ b/lingbot_map/vis/utils.py
@@ -14,6 +14,7 @@ from typing import Optional, Tuple
 import numpy as np
 import torch
 import cv2
+import matplotlib
 import matplotlib.cm as cm
 
 
@@ -67,7 +68,7 @@ def get_vertical_colorbar(
     canvas = FigureCanvasAgg(fig)
 
     ax = fig.add_subplot(111)
-    cmap = cm.get_cmap(cmap_name)
+    cmap = matplotlib.colormaps.get_cmap(cmap_name)
     norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
 
     tick_cnt = 6
@@ -135,7 +136,7 @@ def colorize_np(
     x = np.clip(x, vmin, vmax)
     x = (x - vmin) / (vmax - vmin)
 
-    cmap = cm.get_cmap(cmap_name)
+    cmap = matplotlib.colormaps.get_cmap(cmap_name)
     x_new = cmap(x)[:, :, :3]
 
     if mask is not None:


### PR DESCRIPTION
## Summary

Enables `demo.py` on Apple Silicon GPUs (MPS backend), tested on an M4 / 48 GB with `lingbot-map-long.pt` on the bundled `example/courthouse` scene (`--use_sdpa`, since FlashInfer is CUDA-only).

- Select `mps` when CUDA is unavailable; run bf16 under a device-aware autocast context
- Make the fp32 guard around the camera/depth/point heads device-aware (`autocast('cuda', enabled=False)` does not disable autocast on other device types, so heads would silently run bf16 on MPS)
- Downcast precomputed RoPE frequencies from complex128 to complex64 when moving to MPS (MPS has no float64); the fp64 precompute on CPU is unchanged
- Fix `matplotlib>=3.9` compat in the viewer (`cm.get_cmap` was removed in 3.9)

CUDA behavior is unchanged in all paths.

## Related PRs

- #17 covers similar ground (MPS device selection with a `--device` flag, auto-SDPA, the same RoPE complex64 downcast) but runs MPS in fp32 without autocast. This PR runs bf16 on MPS — matching the CUDA inference dtype at roughly half the activation/KV memory — which is what required the device-aware autocast and fp32-head-guard changes above. Happy to rebase onto #17's `--device` UX if that PR is preferred as the base.
- #85 adds CPU-first inference with a `utils/device.py` device/dtype resolution layer and soft FlashInfer→SDPA fallback; if it lands first, the MPS branch here would slot naturally into those helpers.
- #50 is a native MLX reimplementation — likely the performance ceiling on Apple Silicon, but a separate stack; this PR is the minimal torch-native path using the existing `demo.py` flags.

## Testing

- `example/courthouse` (286 frames, streaming, `--mask_sky --use_sdpa`) on M4 (macOS 26, torch 2.13): full run in progress at time of writing (~1.5 it/s early, slowing as the KV cache grows); will confirm completion + viewer output in a comment
- 12-frame smoke test end-to-end through inference, post-processing, and the viser viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)