### PR TITLE
docs: fix demo.py usage paths

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -2,19 +2,19 @@
 
 Usage:
     # Streaming inference (frame-by-frame with KV cache)
-    python examples/demo.py --model_path /path/to/checkpoint.pt \
+    python demo.py --model_path /path/to/checkpoint.pt \
         --image_folder /path/to/images/
 
     # Streaming inference with keyframe KV caching
-    python examples/demo.py --model_path /path/to/checkpoint.pt \
+    python demo.py --model_path /path/to/checkpoint.pt \
         --image_folder /path/to/images/ --mode streaming --keyframe_interval 6
 
     # Windowed inference (for very long sequences, >500 frames)
-    python examples/demo.py --model_path /path/to/checkpoint.pt \
+    python demo.py --model_path /path/to/checkpoint.pt \
         --video_path video.mp4 --fps 10 --mode windowed --window_size 64
 
     # From video with custom FPS sampling
-    python examples/demo.py --model_path /path/to/checkpoint.pt \
+    python demo.py --model_path /path/to/checkpoint.pt \
         --video_path video.mp4 --fps 10
 """
 


### PR DESCRIPTION
## Summary

Correct the four usage examples in the module docstring so they invoke the script at its actual repository-root path.

## Why

`demo.py` is at the repository root; there is no `examples/demo.py`. Copying any of the previous commands therefore failed before argument parsing.

## Validation

- Parsed the module docstring and confirmed all four examples use `python demo.py`.
- Confirmed no `examples/demo.py` reference remains in the docstring.
- Rebased onto the current `main`; the PR now changes only `demo.py`.
