### PR TITLE
fix: align pyproject dependencies with README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "LingBot-Map: Geometric Context Transformer for Streaming 3D Reconstruction"
 requires-python = ">= 3.10"
 dependencies = [
+    "numpy<2",
     "Pillow",
     "huggingface_hub",
     "einops",
@@ -15,6 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 vis = ["viser>=0.2.23", "trimesh", "matplotlib", "onnxruntime", "requests"]
+render = ["open3d>=0.19", "pyyaml"]
 demo = ["lingbot-map[vis]"]
 
 [build-system]


### PR DESCRIPTION
## Summary

Align the package metadata with the installation path already documented in the README.

## Changes

- Declare the documented core constraint `numpy<2`.
- Define the missing `render` extra with `open3d>=0.19` and `pyyaml`, so `pip install -e ".[vis,render]"` resolves the dependencies used by the rendering pipeline.

PyTorch is intentionally not added as a generic dependency: the README requires users to select a build that matches their CUDA and Kaolin environment.

## Validation

- Parsed `pyproject.toml` and checked both dependency groups.
- Built `lingbot_map-0.1.0-py3-none-any.whl` successfully.
- Inspected wheel metadata and confirmed `numpy<2`, the `render` extra, `open3d>=0.19`, and `pyyaml` are present.
- Rebased onto the current `main`; the PR now changes only `pyproject.toml`.
