### PR TITLE
fix: build GLB point cloud from depth when world_points is absent

### DIFF
--- a/lingbot_map/vis/glb_export.py
+++ b/lingbot_map/vis/glb_export.py
@@ -17,6 +17,7 @@ import cv2
 import matplotlib
 from scipy.spatial.transform import Rotation
 
+from lingbot_map.utils.geometry import unproject_depth_map_to_point_map
 from lingbot_map.vis.sky_segmentation import (
     _SKYSEG_INPUT_SIZE,
     _SKYSEG_SOFT_THRESHOLD,
@@ -30,6 +31,38 @@ try:
 except ImportError:
     trimesh = None
     print("trimesh not found. GLB export will not work.")
+
+
+def _world_points_from_depth(predictions: dict) -> np.ndarray:
+    """Unproject predicted depth maps into world-space points.
+
+    The released checkpoints are trained with the point head disabled
+    (``GCTStream`` defaults to ``enable_point=False``), so ``predictions`` has
+    no ``world_points`` key and the point cloud has to be built from depth plus
+    camera parameters. This mirrors what the interactive viewers already do,
+    so GLB exports and the viser preview show the same geometry.
+
+    Args:
+        predictions: Prediction dict containing ``depth`` (S, H, W, 1),
+            ``extrinsic`` (S, 3, 4) and ``intrinsic`` (S, 3, 3).
+
+    Returns:
+        np.ndarray: World points of shape (S, H, W, 3).
+
+    Raises:
+        KeyError: If any of the required keys is missing.
+    """
+    required = ("depth", "extrinsic", "intrinsic")
+    missing = [key for key in required if predictions.get(key) is None]
+    if missing:
+        raise KeyError(
+            "cannot build a point cloud from depth: predictions is missing "
+            f"{', '.join(missing)}. Available keys: {sorted(predictions)}"
+        )
+
+    return unproject_depth_map_to_point_map(
+        predictions["depth"], predictions["extrinsic"], predictions["intrinsic"]
+    )
 
 
 def predictions_to_glb(
@@ -48,10 +81,14 @@ def predictions_to_glb(
 
     Args:
         predictions: Dictionary containing model predictions with keys:
-            - world_points: 3D point coordinates (S, H, W, 3)
-            - world_points_conf: Confidence scores (S, H, W)
             - images: Input images (S, H, W, 3) or (S, 3, H, W)
             - extrinsic: Camera extrinsic matrices (S, 3, 4)
+            - intrinsic: Camera intrinsic matrices (S, 3, 3)
+            - world_points: 3D point coordinates (S, H, W, 3), optional
+            - world_points_conf: Confidence scores (S, H, W), optional
+            - depth: Depth maps (S, H, W, 1), used to build the point cloud
+              whenever world_points is absent
+            - depth_conf: Depth confidence (S, H, W), optional
         conf_thres: Percentage of low-confidence points to filter out
         filter_by_frames: Frame filter specification ("all" or frame index)
         mask_black_bg: Mask out black background pixels
@@ -97,13 +134,13 @@ def predictions_to_glb(
             )
         else:
             print("Warning: world_points not found, falling back to depth-based points")
-            pred_world_points = predictions["world_points_from_depth"]
+            pred_world_points = _world_points_from_depth(predictions)
             pred_world_points_conf = predictions.get(
                 "depth_conf", np.ones_like(pred_world_points[..., 0])
             )
     else:
         print("Using Depthmap and Camera Branch")
-        pred_world_points = predictions["world_points_from_depth"]
+        pred_world_points = _world_points_from_depth(predictions)
         pred_world_points_conf = predictions.get(
             "depth_conf", np.ones_like(pred_world_points[..., 0])
         )


### PR DESCRIPTION
Fixes #96.

## Problem

`--save_glb` always fails, in both prediction modes:

```
Building GLB scene
Using Pointmap Branch
Warning: world_points not found, falling back to depth-based points
Error processing courthouse : 'world_points_from_depth'
```

`predictions_to_glb` reads `predictions["world_points_from_depth"]`, but nothing in the repository ever writes that key:

```console
$ grep -rn "world_points_from_depth" --include="*.py" .
lingbot_map/vis/glb_export.py:100:            pred_world_points = predictions["world_points_from_depth"]
lingbot_map/vis/glb_export.py:106:        pred_world_points = predictions["world_points_from_depth"]
```

Two readers, zero writers. The depth fallback raises `KeyError` instead of falling back.

It fires on every export because the released checkpoints disable the point head:

1. `GCTStream` defaults to `enable_point=False` (`gct_stream.py:96`)
2. so `point_head is None` (`gct_base.py:93`)
3. so `_predict_points()` returns `{}` and there is no `world_points` key
4. so `predictions_to_glb` takes the fallback branch and dies

`"Predicted Pointmap"` falls through to line 100; `"Predicted Depthmap"` hits line 106 unconditionally.

The interactive viewers are unaffected because they never use this key — they compute the points themselves.

## Fix

Compute the points rather than reading a key nothing produces, using the same call `point_cloud_viewer.py:167` and `viser_wrapper.py:76` already make:

```python
unproject_depth_map_to_point_map(depth, extrinsic, intrinsic)
```

Reusing that call keeps GLB output geometrically identical to the viser preview, and passes `extrinsic` through unmodified exactly as the viewers do.

Also included:
- `_world_points_from_depth()` raises an actionable `KeyError` naming which of `depth` / `extrinsic` / `intrinsic` is missing, instead of failing on a key the user has never heard of.
- Docstring corrected: it listed `world_points` as a required input when it is optional, and omitted `intrinsic` and `depth` entirely.

One file, +41 / −4. No behaviour change when `world_points` is present.

## Verification

`predictions_to_glb` is pure numpy/trimesh, so it can be exercised directly with a predictions dict shaped like the one in the issue report (`pose_enc`, `depth`, `depth_conf`, `extrinsic`, `intrinsic`, `images`) — no GPU or checkpoint required.

| Check | Before | After |
| --- | --- | --- |
| `"Predicted Pointmap"` | `KeyError` | scene built |
| `"Predicted Depthmap"` | `KeyError` | scene built |
| `world_points` present (regression) | ok | ok, still uses the pointmap branch |
| Exported file | none | valid glTF container, verified magic bytes |
| `depth` missing | `KeyError` on the wrong key | error names the missing key |

I also rendered a synthetic ray-cast scene through the full export path and opened the resulting `.glb` to confirm the geometry is correct and the camera frustums line up with the point cloud.

Happy to adjust the approach if you would rather populate `world_points_from_depth` upstream in `demo_render/batch_demo.py` instead — I went with fixing the consumer since `demo.py` and any other caller would otherwise need the same change.
