### PR TITLE
Fix GPU memory waste in demo.py and a viewer scene-corruption bug

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -151,7 +151,7 @@ def load_model(args, device):
 
     if args.model_path:
         print(f"Loading checkpoint: {args.model_path}")
-        ckpt = torch.load(args.model_path, map_location=device, weights_only=False)
+        ckpt = torch.load(args.model_path, map_location="cpu", weights_only=False)
         state_dict = ckpt.get("model", ckpt)
         missing, unexpected = model.load_state_dict(state_dict, strict=False)
         if missing:
@@ -459,7 +459,13 @@ def main():
         print(f"Casting aggregator to {dtype} (heads kept in fp32)")
         model.aggregator = model.aggregator.to(dtype=dtype)
 
-    images = images.to(device)
+    if device.type == "cuda":
+        # Keep the full clip on CPU (pinned for fast async H2D copies).
+        # inference_streaming/inference_windowed already slice off one
+        # frame at a time and move just that slice to GPU internally, so
+        # eagerly moving the whole sequence here only wastes VRAM holding
+        # thousands of frames' pixels for the ~1 that's ever in flight.
+        images = images.pin_memory()
     num_frames = images.shape[0]
     print(f"Input: {num_frames} frames, shape {tuple(images.shape)}")
     print(f"Mode: {args.mode}")

--- a/demo_render/render_cuda_ext/setup.py
+++ b/demo_render/render_cuda_ext/setup.py
@@ -1,5 +1,18 @@
+import sys
+
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+if sys.platform == 'win32':
+    # MSVC defaults to a non-conforming preprocessor and an older C++
+    # standard, which chokes on pybind11/torch's macro-heavy headers.
+    # Neither flag is needed (or understood) by gcc/clang, so keep this
+    # Windows-only rather than passing it to every platform's compiler.
+    win_cxx_args = ['/std:c++20', '/Zc:preprocessor']
+    win_nvcc_args = ['-std=c++20', '-Xcompiler=/Zc:preprocessor']
+else:
+    win_cxx_args = []
+    win_nvcc_args = []
 
 setup(
     name='render_cuda_ext',
@@ -11,7 +24,10 @@ setup(
                 'voxel_morton/voxel_morton_bind.cpp',
                 'voxel_morton/voxel_morton.cu',
             ],
-            extra_compile_args={'nvcc': ['-O3', '--use_fast_math']},
+            extra_compile_args={
+                'cxx': win_cxx_args,
+                'nvcc': ['-O3', '--use_fast_math'] + win_nvcc_args,
+            },
         ),
         CUDAExtension(
             'frustum_cull_ext',
@@ -19,7 +35,10 @@ setup(
                 'frustum_cull/frustum_cull_bind.cpp',
                 'frustum_cull/frustum_cull.cu',
             ],
-            extra_compile_args={'nvcc': ['-O2']},
+            extra_compile_args={
+                'cxx': win_cxx_args,
+                'nvcc': ['-O2'] + win_nvcc_args,
+            },
         ),
     ],
     cmdclass={'build_ext': BuildExtension},

--- a/lingbot_map/vis/point_cloud_viewer.py
+++ b/lingbot_map/vis/point_cloud_viewer.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 import cv2
 import matplotlib.cm as cm
+import matplotlib
 from tqdm.auto import tqdm
 
 import viser
@@ -536,6 +537,7 @@ class PointCloudViewer:
 
         self.pc_handles = []
         self.cam_handles = []
+        self.cam_frame_handles = []
 
         @self.psize_slider.on_update
         def _(_) -> None:
@@ -611,9 +613,16 @@ class PointCloudViewer:
         for handle in self.cam_handles:
             try:
                 handle.remove()
-            except (KeyError, AttributeError):
+            except (KeyError, AttributeError, RuntimeError):
                 pass
         self.cam_handles.clear()
+
+        for handle in self.cam_frame_handles:
+            try:
+                handle.remove()
+            except (KeyError, AttributeError, RuntimeError):
+                pass
+        self.cam_frame_handles.clear()
 
         if self.show_camera:
             downsample_factor = int(self.camera_downsample_slider.value)
@@ -1045,7 +1054,7 @@ class PointCloudViewer:
             normalized_indices = np.array(list(range(num_cameras))) / (num_cameras - 1)
         else:
             normalized_indices = np.array([0.0])
-        cmap = cm.get_cmap('viridis')
+        cmap = matplotlib.colormaps['viridis']
         self.camera_colors = cmap(normalized_indices)
         return pcs, step_list
 
@@ -1134,7 +1143,7 @@ class PointCloudViewer:
         camera_color = self.camera_colors[step_index]
         camera_color_rgb = tuple((camera_color[:3] * 255).astype(int))
 
-        self.server.scene.add_frame(
+        camera_frame_handle = self.server.scene.add_frame(
             f"/frames/{step}/camera_frame",
             wxyz=q,
             position=t,
@@ -1142,6 +1151,7 @@ class PointCloudViewer:
             axes_radius=0.002,
             origin_radius=0.002,
         )
+        self.cam_frame_handles.append(camera_frame_handle)
 
         frustum_handle = self.server.scene.add_camera_frustum(
             name=f"/frames/{step}/camera",


### PR DESCRIPTION
## Summary

Three independent fixes found while running `demo.py` end-to-end on a real capture (native Windows + WSL2):

- **demo.py**: the full image sequence was eagerly copied to GPU before inference even though `inference_streaming`/`inference_windowed` already slice off and transfer one frame at a time internally. On longer sequences this wastes several GB of VRAM holding pixels for frames that aren't being processed yet, and was directly responsible for OOMs on an 8GB GPU. Also switched the checkpoint load to `map_location="cpu"` to avoid a transient double-memory-copy at load time.
- **lingbot_map/vis/point_cloud_viewer.py**: `_regenerate_cameras()` (triggered by the camera downsample slider, and hit repeatedly during `save_video()`) removed and recreated frustum handles but never cleaned up the paired `camera_frame` axes `FrameHandle` it also creates. Re-adding a node at an already-live path eventually raises `Cannot assign to 'position'/'visible' on a removed FrameHandle`. Since viser replays its full scene-edit history to every newly-connecting client, this error gets baked permanently into that history — once triggered, the viewer is broken for all future connections until the server process is restarted, with no way to recover the in-memory reconstruction short of a full rerun. Also fixed a `matplotlib.cm.get_cmap` deprecation warning (removed in newer matplotlib).
- **demo_render/render_cuda_ext/setup.py**: the CUDA extensions failed to build at all on native Windows (MSVC) — added the required `/std:c++20` / `/Zc:preprocessor` flags, gated to `sys.platform == 'win32'` so Linux/macOS builds are unaffected.

## Test plan

- [x] Ran `demo.py` in both `--mode streaming` and `--mode windowed` on native Windows through a full room-scan clip; confirmed GPU memory no longer includes the full image sequence and the run completes without the memory-growth OOM seen before.
- [x] Reproduced the viewer corruption (drag camera downsample slider a few times, or click Save Video) before the fix, confirmed it no longer occurs after tracking/removing `camera_frame` handles.
- [x] Built the CUDA extensions on native Windows with MSVC after the `setup.py` change; confirmed the `win32`-gated flags don't touch the Linux/macOS compile args path.